### PR TITLE
do not fail when concat an empty list

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -196,7 +196,7 @@ def bdh_wrapper(
             df = pd.concat(df)
             df = df.reset_index().rename(columns={"index": "date"})
         else:
-            df = pd.DataFrame(columns=[ticker.lower() for ticker in tickers])
+            df = pd.DataFrame(columns=[field.lower() for field in fields])
         log["status"] = "OK"
         collection.insert_one(log)
         return df

--- a/utils.py
+++ b/utils.py
@@ -196,7 +196,7 @@ def bdh_wrapper(
             df = pd.concat(df)
             df = df.reset_index().rename(columns={"index": "date"})
         else:
-            df = pd.DataFrame(columns=[field.lower() for field in fields])
+            df = pd.DataFrame(columns=[field.lower() for field in fields] + ["isin"])
         log["status"] = "OK"
         collection.insert_one(log)
         return df

--- a/utils.py
+++ b/utils.py
@@ -184,7 +184,9 @@ def bdh_wrapper(
     else:
         df = []
         for key, value in response.json().items():
-            isin, field = key.replace("(", "").replace(")", "").replace("'", "").split(",")
+            isin, field = (
+                key.replace("(", "").replace(")", "").replace("'", "").split(",")
+            )
             field = field.strip()
             df_temp = pd.DataFrame.from_dict(value, orient="index", columns=[field])
             df_temp.index = pd.to_datetime(df_temp.index, unit="ms")
@@ -194,7 +196,7 @@ def bdh_wrapper(
             df = pd.concat(df)
             df = df.reset_index().rename(columns={"index": "date"})
         else:
-            df = pd.DataFrame()
+            df = pd.DataFrame(columns=[ticker.lower() for ticker in tickers])
         log["status"] = "OK"
         collection.insert_one(log)
         return df

--- a/utils.py
+++ b/utils.py
@@ -190,8 +190,11 @@ def bdh_wrapper(
             df_temp.index = pd.to_datetime(df_temp.index, unit="ms")
             df_temp["isin"] = correlation_id_to_isin(isin)
             df.append(df_temp)
-        df = pd.concat(df)
-        df = df.reset_index().rename(columns={"index": "date"})
+        if df:
+            df = pd.concat(df)
+            df = df.reset_index().rename(columns={"index": "date"})
+        else:
+            df = pd.DataFrame()
         log["status"] = "OK"
         collection.insert_one(log)
         return df


### PR DESCRIPTION
This happens when the response.json() is an empty dictionary, so the for loop doesn't append any dfs to the list.

This is needed by regression_historical_data: sometimes, when we are requesting few dates, we only retrieve an empty response.

tested locally